### PR TITLE
Add Python supporting and special-case files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /build/
 .DS_Store
 /src-generated/java/
+/src-generated/python/
+__pycache__/
 /nbproject/genfiles.properties

--- a/build.xml
+++ b/build.xml
@@ -1117,8 +1117,30 @@ WarfareFamilyPdus.xml
             </classpath>
         </java>
 
+        <!-- Stage 6: Delete auto-generated classes replaced by special-case versions -->
+        <echo message="--- Stage 6: Replace auto-generated with special-case/supporting Python files ---"/>
+        <delete file="src-generated/python/opendis7/pdus/VariableDatum.py"/>
+        <delete file="src-generated/python/opendis7/pdus/SignalPdu.py"/>
+        <delete file="src-generated/python/opendis7/pdus/IntercomSignalPdu.py"/>
+        <delete file="src-generated/python/opendis7/pdus/PduStatus.py"/>
+        <delete file="src-generated/python/opendis7/pdus/Domain.py"/>
+
+        <!-- Copy supporting Python files (e.g. PduStatus with named bit flags) -->
+        <copy todir="src-generated/python/opendis7" overwrite="true">
+            <fileset dir="src-supporting/python/opendis7">
+                <include name="**/*.py"/>
+            </fileset>
+        </copy>
+
+        <!-- Copy special-case Python files (hand-crafted replacements) -->
+        <copy todir="src-generated/python/opendis7" overwrite="true">
+            <fileset dir="src-specialcase/python/opendis7">
+                <include name="**/*.py"/>
+            </fileset>
+        </copy>
+
         <echo message="=================================================================================="/>
         <echo message="generate-source-code-python complete"/>
     </target>
-    
+
 </project>

--- a/src-specialcase/python/opendis7/pdus/Domain.py
+++ b/src-specialcase/python/opendis7/pdus/Domain.py
@@ -1,0 +1,67 @@
+#
+# Copyright (c) 2008-2023, MOVES Institute, Naval Postgraduate School (NPS).
+# All rights reserved.
+# This work is provided under a BSD open-source license, see project
+# license.html and license.txt
+#
+
+from __future__ import annotations
+
+
+class Domain(object):
+    """Which domain does this PDU belong to. Wraps domain enum values
+    (PlatformDomain, MunitionDomain, SupplyDomain) with a unified interface."""
+
+    def __init__(self):
+        """Initializer for Domain."""
+        self._enum_value = 0
+        self._description = ""
+
+    @classmethod
+    def inst(cls, enum_or_int):
+        """Factory method to create a Domain from an enum or int value.
+
+        Args:
+            enum_or_int: A PlatformDomain, MunitionDomain, SupplyDomain enum
+                         or an integer value.
+
+        Returns:
+            A Domain instance wrapping the given value.
+        """
+        d = cls()
+        if hasattr(enum_or_int, 'value'):
+            d._enum_value = enum_or_int.value
+            if hasattr(enum_or_int, 'name'):
+                d._description = enum_or_int.name
+        else:
+            d._enum_value = int(enum_or_int)
+            d._description = str(enum_or_int)
+        return d
+
+    @property
+    def value(self):
+        return self._enum_value
+
+    @property
+    def description(self):
+        return self._description
+
+    def marshalledSize(self):
+        """Return the marshalled size of this object in bytes."""
+        return 1
+
+    def serialize(self, outputStream):
+        """Serialize the class to a DataOutputStream."""
+        outputStream.write_unsigned_byte(self._enum_value)
+
+    def parse(self, inputStream):
+        """Parse a message. This may recursively call embedded objects."""
+        self._enum_value = inputStream.read_unsigned_byte()
+
+    def __eq__(self, other):
+        if isinstance(other, Domain):
+            return self._enum_value == other._enum_value
+        return NotImplemented
+
+    def __repr__(self):
+        return "Domain: " + self._description + " (" + str(self._enum_value) + ")"

--- a/src-specialcase/python/opendis7/pdus/IntercomSignalPdu.py
+++ b/src-specialcase/python/opendis7/pdus/IntercomSignalPdu.py
@@ -1,0 +1,99 @@
+#
+# Copyright (c) 2008-2023, MOVES Institute, Naval Postgraduate School (NPS).
+# All rights reserved.
+# This work is provided under a BSD open-source license, see project
+# license.html and license.txt
+#
+
+from __future__ import annotations
+
+from opendis7.pdus.RadioCommunicationsFamilyPdu import RadioCommunicationsFamilyPdu
+from opendis7.pdus.IntercomReferenceID import IntercomReferenceID
+from opendis7.enumerations.DisPduType import DisPduType
+from opendis7.enumerations.SignalTDLType import SignalTDLType
+
+
+class IntercomSignalPdu(RadioCommunicationsFamilyPdu):
+    """5.8.6 Conveys the audio or digital data that is used to communicate between simulated intercom devices"""
+
+    def __init__(self):
+        """Initializer for IntercomSignalPdu."""
+        super().__init__()
+        self.pduType = DisPduType.INTERCOM_SIGNAL
+        self.intercomReferenceID = IntercomReferenceID()
+        """The unique designation of an attached or unattached intercom in an event or exercise"""
+        self.intercomNumber = 0
+        """ID of communications device"""
+        self.encodingScheme = 0
+        """encoding scheme"""
+        self.tdlType = SignalTDLType(0)
+        """tactical data link type"""
+        self.sampleRate = 0
+        """sample rate"""
+        self.dataLength = 0
+        """data length in bits"""
+        self.samples = 0
+        """samples"""
+        self.data = b''
+        """variable-length data payload"""
+
+    def marshalledSize(self):
+        """Return the marshalled size of this object in bytes."""
+        marshalSize = super().marshalledSize()
+        marshalSize += self.intercomReferenceID.marshalledSize()
+        marshalSize += 2  # intercomNumber (uint16)
+        marshalSize += 2  # encodingScheme (uint16)
+        marshalSize += 2  # tdlType (uint16 enum)
+        marshalSize += 4  # sampleRate (uint32)
+        marshalSize += 2  # dataLength (uint16)
+        marshalSize += 2  # samples (uint16)
+        byteLength = (self.dataLength + 7) // 8
+        marshalSize += byteLength
+        # Pad to 32-bit boundary
+        remainder = marshalSize % 4
+        if remainder != 0:
+            marshalSize += 4 - remainder
+        return marshalSize
+
+    def serialize(self, outputStream):
+        """Serialize the class to a DataOutputStream."""
+        # Auto-compute dataLength if not explicitly set
+        if self.dataLength == 0 and len(self.data) > 0:
+            self.dataLength = len(self.data) * 8
+
+        self.length = self.marshalledSize()
+        super().serialize(outputStream)
+        self.intercomReferenceID.serialize(outputStream)
+        outputStream.write_unsigned_short(self.intercomNumber)
+        outputStream.write_unsigned_short(self.encodingScheme)
+        outputStream.write_unsigned_short(self.tdlType.value)
+        outputStream.write_unsigned_int(self.sampleRate)
+        outputStream.write_unsigned_short(self.dataLength)
+        outputStream.write_unsigned_short(self.samples)
+
+        byteLength = (self.dataLength + 7) // 8
+        outputStream.stream.write(self.data[:byteLength])
+
+        # Pad to 32-bit boundary
+        currentPosition = outputStream.stream.tell()
+        padCount = (4 - (currentPosition % 4)) % 4
+        outputStream.stream.write(b'\x00' * padCount)
+
+    def parse(self, inputStream):
+        """Parse a message. This may recursively call embedded objects."""
+        super().parse(inputStream)
+        self.intercomReferenceID.parse(inputStream)
+        self.intercomNumber = inputStream.read_unsigned_short()
+        self.encodingScheme = inputStream.read_unsigned_short()
+        self.tdlType = SignalTDLType(inputStream.read_unsigned_short())
+        self.sampleRate = inputStream.read_unsigned_int()
+        self.dataLength = inputStream.read_unsigned_short()
+        self.samples = inputStream.read_unsigned_short()
+
+        byteLength = (self.dataLength + 7) // 8
+        self.data = inputStream.stream.read(byteLength)
+
+        # Pad to 32-bit boundary
+        currentPosition = inputStream.stream.tell()
+        padCount = (4 - (currentPosition % 4)) % 4
+        inputStream.stream.read(padCount)

--- a/src-specialcase/python/opendis7/pdus/SignalPdu.py
+++ b/src-specialcase/python/opendis7/pdus/SignalPdu.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2008-2023, MOVES Institute, Naval Postgraduate School (NPS).
+# All rights reserved.
+# This work is provided under a BSD open-source license, see project
+# license.html and license.txt
+#
+
+from __future__ import annotations
+
+from opendis7.pdus.RadioCommunicationsFamilyPdu import RadioCommunicationsFamilyPdu
+from opendis7.pdus.RadioCommsHeader import RadioCommsHeader
+from opendis7.enumerations.DisPduType import DisPduType
+from opendis7.enumerations.SignalTDLType import SignalTDLType
+
+
+class SignalPdu(RadioCommunicationsFamilyPdu):
+    """5.8.4 Conveys the audio or digital data carried by the simulated radio or intercom transmission."""
+
+    def __init__(self):
+        """Initializer for SignalPdu."""
+        super().__init__()
+        self.pduType = DisPduType.SIGNAL
+        self.header = RadioCommsHeader()
+        """Radio communications header"""
+        self.encodingScheme = 0
+        """encoding scheme used, and enumeration"""
+        self.tdlType = SignalTDLType(0)
+        """tdl type"""
+        self.sampleRate = 0
+        """sample rate"""
+        self.dataLength = 0
+        """length of data in bits"""
+        self.samples = 0
+        """number of samples"""
+        self.data = b''
+        """variable-length data payload"""
+
+    def marshalledSize(self):
+        """Return the marshalled size of this object in bytes."""
+        marshalSize = super().marshalledSize()
+        marshalSize += self.header.marshalledSize()
+        marshalSize += 2  # encodingScheme (uint16)
+        marshalSize += 2  # tdlType (uint16 enum)
+        marshalSize += 4  # sampleRate (uint32)
+        marshalSize += 2  # dataLength (uint16)
+        marshalSize += 2  # samples (uint16)
+        byteLength = (self.dataLength + 7) // 8
+        marshalSize += byteLength
+        # Pad to 32-bit boundary
+        remainder = marshalSize % 4
+        if remainder != 0:
+            marshalSize += 4 - remainder
+        return marshalSize
+
+    def serialize(self, outputStream):
+        """Serialize the class to a DataOutputStream."""
+        # Auto-compute dataLength if not explicitly set
+        if self.dataLength == 0 and len(self.data) > 0:
+            self.dataLength = len(self.data) * 8
+
+        self.length = self.marshalledSize()
+        super().serialize(outputStream)
+        self.header.serialize(outputStream)
+        outputStream.write_unsigned_short(self.encodingScheme)
+        outputStream.write_unsigned_short(self.tdlType.value)
+        outputStream.write_unsigned_int(self.sampleRate)
+        outputStream.write_unsigned_short(self.dataLength)
+        outputStream.write_unsigned_short(self.samples)
+
+        byteLength = (self.dataLength + 7) // 8
+        outputStream.stream.write(self.data[:byteLength])
+
+        # Pad to 32-bit boundary
+        currentPosition = outputStream.stream.tell()
+        padCount = (4 - (currentPosition % 4)) % 4
+        outputStream.stream.write(b'\x00' * padCount)
+
+    def parse(self, inputStream):
+        """Parse a message. This may recursively call embedded objects."""
+        super().parse(inputStream)
+        self.header.parse(inputStream)
+        self.encodingScheme = inputStream.read_unsigned_short()
+        self.tdlType = SignalTDLType(inputStream.read_unsigned_short())
+        self.sampleRate = inputStream.read_unsigned_int()
+        self.dataLength = inputStream.read_unsigned_short()
+        self.samples = inputStream.read_unsigned_short()
+
+        byteLength = (self.dataLength + 7) // 8
+        self.data = inputStream.stream.read(byteLength)
+
+        # Pad to 32-bit boundary
+        currentPosition = inputStream.stream.tell()
+        padCount = (4 - (currentPosition % 4)) % 4
+        inputStream.stream.read(padCount)

--- a/src-specialcase/python/opendis7/pdus/VariableDatum.py
+++ b/src-specialcase/python/opendis7/pdus/VariableDatum.py
@@ -1,0 +1,67 @@
+#
+# Copyright (c) 2008-2023, MOVES Institute, Naval Postgraduate School (NPS).
+# All rights reserved.
+# This work is provided under a BSD open-source license, see project
+# license.html and license.txt
+#
+
+from __future__ import annotations
+
+from opendis7.enumerations.VariableRecordType import VariableRecordType
+
+
+class VariableDatum(object):
+    """The variable datum type, the datum length, and the value for that variable datum type. Section 6.2.93"""
+
+    def __init__(self):
+        """Initializer for VariableDatum."""
+        self.variableDatumID = VariableRecordType(0)
+        """Type of variable datum to be transmitted. 32-bit enumeration defined in EBV"""
+        self.variableDatumLength = 0
+        """Length, IN BITS, of the variable datum."""
+        self.variableDatumValue = b''
+        """Variable-length datum value as raw bytes."""
+
+    def marshalledSize(self):
+        """Return the marshalled size of this object in bytes."""
+        marshalSize = 0
+        marshalSize += 4  # variableDatumID (uint32 enum)
+        marshalSize += 4  # variableDatumLength (uint32)
+        byteLength = (self.variableDatumLength + 7) // 8
+        marshalSize += byteLength
+        # Pad to 64-bit boundary
+        remainder = marshalSize % 8
+        if remainder != 0:
+            marshalSize += 8 - remainder
+        return marshalSize
+
+    def serialize(self, outputStream):
+        """Serialize the class to a DataOutputStream."""
+        # Auto-compute variableDatumLength if not explicitly set
+        if self.variableDatumLength == 0 and len(self.variableDatumValue) > 0:
+            self.variableDatumLength = len(self.variableDatumValue) * 8
+
+        outputStream.write_unsigned_int(self.variableDatumID.value)
+        outputStream.write_unsigned_int(self.variableDatumLength)
+
+        byteLength = (self.variableDatumLength + 7) // 8
+        outputStream.stream.write(self.variableDatumValue[:byteLength])
+
+        # Pad to 64-bit boundary (8 bytes)
+        # Total so far: 4 (ID) + 4 (length) + byteLength = 8 + byteLength
+        currentPosition = outputStream.stream.tell()
+        padCount = (8 - (currentPosition % 8)) % 8
+        outputStream.stream.write(b'\x00' * padCount)
+
+    def parse(self, inputStream):
+        """Parse a message. This may recursively call embedded objects."""
+        self.variableDatumID = VariableRecordType(inputStream.read_unsigned_int())
+        self.variableDatumLength = inputStream.read_unsigned_int()
+
+        byteLength = (self.variableDatumLength + 7) // 8
+        self.variableDatumValue = inputStream.stream.read(byteLength)
+
+        # Pad to 64-bit boundary (8 bytes)
+        currentPosition = inputStream.stream.tell()
+        padCount = (8 - (currentPosition % 8)) % 8
+        inputStream.stream.read(padCount)

--- a/src-specialcase/python/opendis7/utilities/DisTime.py
+++ b/src-specialcase/python/opendis7/utilities/DisTime.py
@@ -1,0 +1,128 @@
+#
+# Copyright (c) 2008-2023, MOVES Institute, Naval Postgraduate School (NPS).
+# All rights reserved.
+# This work is provided under a BSD open-source license, see project
+# license.html and license.txt
+#
+
+"""DIS timestamp configuration and conversion utilities.
+
+DIS time units are defined by IEEE DIS Protocol specification as
+2^31 - 1 time units per hour. The timestamp field in the PDU header is
+four bytes (unsigned int). Each time unit represents approximately
+1.67638 microseconds.
+
+Absolute timestamps have their LSB set to 1 (host synchronized to UTC via NTP).
+Relative timestamps have their LSB set to 0 (host not synchronized).
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from enum import IntEnum
+
+
+class TimestampStyle(IntEnum):
+    """Supported timestamp styles."""
+    IEEE_ABSOLUTE = 0
+    IEEE_RELATIVE = 1
+    UNIX = 2
+
+
+# 2^31 - 1 DIS time units per hour
+DIS_TIME_UNITS_PER_HOUR = 2147483647
+
+ABSOLUTE_TIMESTAMP_MASK = 0x00000001
+RELATIVE_TIMESTAMP_MASK = 0xFFFFFFFE
+
+
+class DisTime:
+    """DIS timestamp utility for generating and converting DIS timestamps."""
+
+    _timestamp_style = TimestampStyle.IEEE_ABSOLUTE
+
+    @staticmethod
+    def get_timestamp_style():
+        """Get the current timestamp style."""
+        return DisTime._timestamp_style
+
+    @staticmethod
+    def set_timestamp_style(style):
+        """Set which timestamp style to use.
+
+        Args:
+            style: A TimestampStyle value.
+        """
+        DisTime._timestamp_style = style
+
+    @staticmethod
+    def get_current_dis_timestamp():
+        """Get the current DIS timestamp based on the configured style.
+
+        Returns:
+            Integer timestamp value.
+        """
+        style = DisTime._timestamp_style
+        if style == TimestampStyle.IEEE_ABSOLUTE:
+            return DisTime._get_absolute_timestamp()
+        elif style == TimestampStyle.IEEE_RELATIVE:
+            return DisTime._get_relative_timestamp()
+        elif style == TimestampStyle.UNIX:
+            return DisTime._get_unix_timestamp()
+        return DisTime._get_absolute_timestamp()
+
+    @staticmethod
+    def _get_dis_time_units_since_top_of_hour():
+        """Compute DIS time units since the top of the current hour.
+
+        Returns:
+            Integer DIS time units.
+        """
+        now = time.time()
+        seconds_since_hour = now % 3600.0
+        fraction_of_hour = seconds_since_hour / 3600.0
+        return int(fraction_of_hour * DIS_TIME_UNITS_PER_HOUR)
+
+    @staticmethod
+    def _get_absolute_timestamp():
+        """IEEE absolute timestamp (LSB = 1, host synchronized to UTC)."""
+        value = DisTime._get_dis_time_units_since_top_of_hour()
+        value = (value << 1) | ABSOLUTE_TIMESTAMP_MASK
+        return value & 0xFFFFFFFF
+
+    @staticmethod
+    def _get_relative_timestamp():
+        """IEEE relative timestamp (LSB = 0, host not synchronized)."""
+        value = DisTime._get_dis_time_units_since_top_of_hour()
+        value = (value << 1) & RELATIVE_TIMESTAMP_MASK
+        return value & 0xFFFFFFFF
+
+    @staticmethod
+    def _get_unix_timestamp():
+        """Unix timestamp (seconds since 1 January 1970)."""
+        return int(time.time()) & 0xFFFFFFFF
+
+    @staticmethod
+    def to_datetime(timestamp):
+        """Convert a Unix-style DIS timestamp to a datetime object.
+
+        Args:
+            timestamp: Integer timestamp in seconds since epoch.
+
+        Returns:
+            A datetime object in UTC.
+        """
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+    @staticmethod
+    def dis_units_to_seconds(dis_units):
+        """Convert DIS time units to seconds within the hour.
+
+        Args:
+            dis_units: Raw DIS time units (31-bit value, before LSB flag).
+
+        Returns:
+            Float seconds since top of hour.
+        """
+        return (dis_units / DIS_TIME_UNITS_PER_HOUR) * 3600.0

--- a/src-specialcase/python/opendis7/utilities/__init__.py
+++ b/src-specialcase/python/opendis7/utilities/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2008-2023, MOVES Institute, Naval Postgraduate School (NPS).
+# All rights reserved.
+# This work is provided under a BSD open-source license, see project
+# license.html and license.txt
+#
+
+from opendis7.utilities.DisTime import DisTime

--- a/src-supporting/python/opendis7/pdus/PduStatus.py
+++ b/src-supporting/python/opendis7/pdus/PduStatus.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2008-2023, MOVES Institute, Naval Postgraduate School (NPS).
+# All rights reserved.
+# This work is provided under a BSD open-source license, see project
+# license.html and license.txt
+#
+
+from __future__ import annotations
+
+
+class PduStatus(object):
+    """PduStatus, section 6.2.67
+
+    Sample use:
+        from opendis7.pdus.PduStatus import PduStatus
+        stat = PduStatus(PduStatus.CEI_COUPLED | PduStatus.LVC_LIVE)
+        stat = PduStatus()
+        stat.value = PduStatus.CEI_NOT_COUPLED | PduStatus.LVC_VIRTUAL | PduStatus.TEI_NO_DIFFERENCE
+    """
+
+    # bit 0 - Transferred Entity Indication
+    TEI_NO_DIFFERENCE = 0b00000000
+    TEI_DIFFERENCE    = 0b00000001
+
+    # bits 1-2 - LVC Indication
+    LVC_NO_STATEMENT  = 0b00000000
+    LVC_LIVE          = 0b00000010
+    LVC_VIRTUAL       = 0b00000100
+    LVC_CONSTRUCTIVE  = 0b00000110
+
+    # bit 3 - Coupled Extension Indication
+    CEI_NOT_COUPLED   = 0b00000000
+    CEI_COUPLED       = 0b00001000
+
+    # bit 4 - Fire Type Indication
+    FTI_MUNITION      = 0b00000000
+    FTI_EXPENDABLE    = 0b00010000
+
+    # bits 4-5 - Detonation Type Indication
+    DTI_MUNITION               = 0b00000000
+    DTI_EXPENDABLE             = 0b00010000
+    DTI_NON_MUNITION_EXPLOSION = 0b00100000
+
+    # bits 4-5 - Radio Attached Indication
+    RAI_NO_STATEMENT  = 0b00000000
+    RAI_UNATTACHED    = 0b00010000
+    RAI_ATTACHED      = 0b00100000
+
+    # bits 4-5 - Intercom Attached Indication
+    IAI_NO_STATEMENT  = 0b00000000
+    IAI_UNATTACHED    = 0b00010000
+    IAI_ATTACHED      = 0b00100000
+
+    # bit 4 - IFF Simulation Mode
+    ISM_REGENERATION  = 0b00000000
+    ISM_INTERACTIVE   = 0b00010000
+
+    # bit 5 - Active Interrogation Indication
+    AII_NOT_ACTIVE    = 0b00000000
+    AII_ACTIVE        = 0b00100000
+
+    def __init__(self, value=0):
+        """Initializer for PduStatus."""
+        self.value = value
+
+    def marshalledSize(self):
+        """Return the marshalled size of this object in bytes."""
+        return 1
+
+    def serialize(self, outputStream):
+        """Serialize the class to a DataOutputStream."""
+        outputStream.write_unsigned_byte(self.value)
+
+    def parse(self, inputStream):
+        """Parse a message. This may recursively call embedded objects."""
+        self.value = inputStream.read_unsigned_byte()
+
+    def __eq__(self, other):
+        if isinstance(other, PduStatus):
+            return self.value == other.value
+        return NotImplemented
+
+    def __repr__(self):
+        return "PduStatus: " + format(self.value, '08b')


### PR DESCRIPTION
## Summary

- Add hand-crafted Python files to replace broken auto-generated versions for VariableDatum, SignalPdu, and IntercomSignalPdu (all had `primitivelist length="0"` causing zero-byte serialization)
- Add PduStatus with named bit flag constants (TEI, LVC, CEI, etc.) and Domain with `inst()` factory method
- Add DisTime timestamp utility for DIS time unit conversion
- Update build.xml Stage 6 to delete auto-generated versions and copy supporting/special-case files, mirroring Java's pattern

## Test plan

- [ ] CI build-python job passes (compile generators, generate, syntax check all 32K+ files)
- [ ] No `null()` found in generated output
- [ ] Package structure verified (pdus, enumerations, entities, objecttypes, jammers, io, utilities)
- [ ] Special-case files contain hand-crafted implementations (verified by grep)

Closes #23